### PR TITLE
Gulp versions may be different

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,3 +1,10 @@
+# 0.3.0
+
+- The registerTasks method has now removed. Instead, the main export is a function that you call, and you must pass along your version of gulp as well.
+```
+	var gulp = require('liferay-gulp-tasks')(require('gulp'), options);
+```
+
 # 0.2.0
 
 - The default repositories ids have been changed to stay consistent with their urls. Now, ids are:

--- a/index.js
+++ b/index.js
@@ -118,4 +118,6 @@ module.exports = function(gulp, opt_options) {
 	gulp.task('maven-publish-snapshot', function(done) {
 		runSequence('prepare-maven-snapshot', 'publish-maven-snapshot', 'clean-maven-dist', done);
 	});
+
+	return gulp;
 };

--- a/index.js
+++ b/index.js
@@ -1,15 +1,14 @@
 'use strict';
 
 var del = require('del');
-var gulp = require('gulp');
 var maven = require('gulp-maven-deploy');
 var path = require('path');
 var runSequence = require('run-sequence');
 
-module.exports.registerTasks = function(opt_options) {
+module.exports = function(gulp, opt_options) {
 	var options = opt_options || {};
 	options.artifactIdPrefix = options.artifactIdPrefix || 'com.liferay.webjars.';
-	options.artifactSrc = options.artifactSrc || ['**/*', '!node_modules/', '!node_modules/**'];
+	options.artifactSrc = options.artifactSrc || ['**/*', '!node_modules/', '!node_modules/**'];
 	options.packageJsonPath = path.resolve(options.packageJsonPath || 'package.json');
 	options.repositories = options.repositories || {
 		releases: [
@@ -31,7 +30,7 @@ module.exports.registerTasks = function(opt_options) {
 	};
 
 	var getName = function() {
-		return options.artifactName || require(options.packageJsonPath).name;
+		return options.artifactName || require(options.packageJsonPath).name;
 	};
 
 	var getVersion = function(config) {


### PR DESCRIPTION
Hey guys,
I'm sending this pull as it's a breaking change to the API, but the problem is as follows:
Because of how NPM resolves it's dependencies, there's no way to guarantee that the version required in this script is the same as the one required in the user's gulpfile.
If this user later upgrades their version of gulp, or has an existing version, it will get overwritten.
There are multiple ways this could be passed in, but in this one, I'm just making it a function that's exported (instead of a method on the exported object), where you pass your gulp instance and your options.
But there are other ways we could do this, just let me know which you prefer.
